### PR TITLE
Fix closing tags in DobraCutaneaForm

### DIFF
--- a/components/StudentDetailView.tsx
+++ b/components/StudentDetailView.tsx
@@ -765,7 +765,10 @@ const DobraCutaneaForm: React.FC<DobraCutaneaFormProps> = ({ dobraInicial, onSub
                             <div key={field.key}>
                                 <label htmlFor={`dobra-${field.key}`} className="block text-xs font-medium text-slate-400 mb-0.5">{field.label}</label>
                                 <input id={`dobra-${field.key}`} name={field.key as string} value={formData[field.key] || ''} {...inputDobraProps} />
-              </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
             ))}
 
 


### PR DESCRIPTION
## Summary
- fix missing closing tags for the grouped fields map in StudentDetailView

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9ca90d28832cacfd6b6b1f0973ea